### PR TITLE
Fixed A2S_Player_Packet timeouts

### DIFF
--- a/src/main/java/com/github/koraktor/steamcondenser/steam/servers/GameServer.java
+++ b/src/main/java/com/github/koraktor/steamcondenser/steam/servers/GameServer.java
@@ -303,7 +303,7 @@ public abstract class GameServer extends Server {
         switch(requestType) {
             case GameServer.REQUEST_CHALLENGE:
                 expectedResponse = S2C_CHALLENGE_Packet.class;
-                requestPacket = new A2S_PLAYER_Packet();
+                requestPacket = new A2S_SERVERQUERY_GETCHALLENGE_Packet();
                 break;
             case GameServer.REQUEST_INFO:
                 expectedResponse = S2A_INFO_BasePacket.class;


### PR DESCRIPTION
Typo in GameServer.java caused A2S_Player_Packet to send without a challenge causing the server to drop it.
